### PR TITLE
refactor(app): move route building logic to builder package

### DIFF
--- a/config/app.go
+++ b/config/app.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/TrinityKnights/Backend/internal/builder"
 	handlerUser "github.com/TrinityKnights/Backend/internal/delivery/http/handler/user"
 	"github.com/TrinityKnights/Backend/internal/delivery/http/middleware"
 	"github.com/TrinityKnights/Backend/internal/delivery/http/route"
@@ -42,12 +43,19 @@ func Bootstrap(config *BootstrapConfig) error {
 	authMiddleware := middleware.AuthMiddleware(jwtService)
 
 	// Initialize route
-	routeConfig := &route.Config{
+	routeConfig := route.Config{
+		App:         config.App,
+		UserHandler: userHandler,
+	}
+
+	// Build routes
+	b := builder.Config{
 		App:            config.App,
 		UserHandler:    userHandler,
 		AuthMiddleware: authMiddleware,
+		Routes:         &routeConfig,
 	}
-	routeConfig.Setup()
+	b.BuildRoutes()
 
 	config.Log.Infof("Application is ready")
 	return nil

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -1,0 +1,38 @@
+package builder
+
+import (
+	"github.com/TrinityKnights/Backend/internal/delivery/http/handler/user"
+	"github.com/TrinityKnights/Backend/internal/delivery/http/route"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+type Config struct {
+	App            *echo.Echo
+	UserHandler    *user.UserHandlerImpl
+	AuthMiddleware echo.MiddlewareFunc
+	Routes         *route.Config
+}
+
+func (c *Config) BuildRoutes() {
+	// Global middleware
+	c.App.Use(middleware.Recover())
+
+	// API group
+	g := c.App.Group("/api/v1")
+	g.Use(middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(60)))
+
+	// Public routes
+	for _, r := range c.Routes.PublicRoute() {
+		g.Add(r.Method, r.Path, r.Handler)
+	}
+
+	// Private routes with auth middleware
+	privateGroup := g.Group("/api/v1", c.AuthMiddleware)
+	for _, r := range c.Routes.PrivateRoute() {
+		privateGroup.Add(r.Method, r.Path, r.Handler)
+	}
+
+	// Swagger routes
+	c.Routes.SwaggerRoutes()
+}

--- a/internal/delivery/http/route/route.go
+++ b/internal/delivery/http/route/route.go
@@ -4,30 +4,21 @@ import (
 	"github.com/TrinityKnights/Backend/internal/delivery/http/handler/user"
 	"github.com/TrinityKnights/Backend/pkg/route"
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 	swagger "github.com/swaggo/echo-swagger"
 )
 
+type RouteConfig interface {
+	PublicRoute() []route.Route
+	PrivateRoute() []route.Route
+	SwaggerRoutes()
+}
+
 type Config struct {
-	App            *echo.Echo
-	UserHandler    *user.UserHandlerImpl
-	AuthMiddleware echo.MiddlewareFunc
+	App         *echo.Echo
+	UserHandler *user.UserHandlerImpl
 }
 
-func (c *Config) Setup() {
-	g := c.App.Group("/api/v1")
-	for _, r := range c.publicRoute() {
-		g.Add(r.Method, r.Path, r.Handler)
-	}
-	for _, r := range c.privateRoute() {
-		g.Add(r.Method, r.Path, r.Handler, c.AuthMiddleware)
-	}
-	g.Use(middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(60)))
-	c.swaggerRoutes()
-	c.App.Use(middleware.Recover())
-}
-
-func (c *Config) publicRoute() []route.Route {
+func (c *Config) PublicRoute() []route.Route {
 	return []route.Route{
 		{
 			Method:  echo.POST,
@@ -47,7 +38,7 @@ func (c *Config) publicRoute() []route.Route {
 	}
 }
 
-func (c *Config) privateRoute() []route.Route {
+func (c *Config) PrivateRoute() []route.Route {
 	return []route.Route{
 		{
 			Method:  echo.GET,
@@ -62,7 +53,7 @@ func (c *Config) privateRoute() []route.Route {
 	}
 }
 
-func (c *Config) swaggerRoutes() {
+func (c *Config) SwaggerRoutes() {
 	c.App.GET("/swagger/*", swagger.WrapHandler)
 
 	c.App.GET("/", func(ctx echo.Context) error {


### PR DESCRIPTION
This pull request introduces a new `builder` package and refactors the route configuration process to improve code organization and readability. The most important changes include the addition of the `builder` package, modifications to the `route` package, and updates to the `config/app.go` file to utilize the new `builder` package.

### Introduction of `builder` package:
* Added a new `builder` package with a `Config` struct and a `BuildRoutes` method to handle route building and middleware setup (`internal/builder/builder.go`).

### Refactoring of `route` package:
* Modified the `route` package to include new methods `PublicRoute`, `PrivateRoute`, and `SwaggerRoutes` for better route management (`internal/delivery/http/route/route.go`). [[1]](diffhunk://#diff-4e3c418151079e59fcbebf1e4c70723eb360f84239b07547433d7eb8456ba521L7-R21) [[2]](diffhunk://#diff-4e3c418151079e59fcbebf1e4c70723eb360f84239b07547433d7eb8456ba521L50-R41) [[3]](diffhunk://#diff-4e3c418151079e59fcbebf1e4c70723eb360f84239b07547433d7eb8456ba521L65-R56)

### Updates to `config/app.go`:
* Updated `config/app.go` to import the new `builder` package and use it for route configuration instead of the previous `Setup` method (`config/app.go`). [[1]](diffhunk://#diff-1c80d698688362936d61c7536127037507d6d0f35976616d664ecdc9ddd7871eR4) [[2]](diffhunk://#diff-1c80d698688362936d61c7536127037507d6d0f35976616d664ecdc9ddd7871eL45-R58)