### PR TITLE
fix(api): remove graceful shutdown and unnecessary imports for Vercel Integration

### DIFF
--- a/api/index.go
+++ b/api/index.go
@@ -1,11 +1,9 @@
 package handler
 
 import (
-	"fmt"
 	"github.com/TrinityKnights/Backend/config"
 	_ "github.com/TrinityKnights/Backend/docs"
 	"net/http"
-	"time"
 )
 
 // Handler is main function to run the application in vercel function
@@ -30,12 +28,5 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		log.Fatalf("Failed to bootstrap application: %v", err)
 	}
 
-	port := viper.GetString("APP_PORT")
-	go func() {
-		if err := app.Start(fmt.Sprintf(":%s", port)); err != nil {
-			log.Fatal("shutting down the server")
-		}
-	}()
-
-	config.GracefulShutdown(app, log, 10*time.Second)
+	app.ServeHTTP(w, r)
 }


### PR DESCRIPTION
This pull request includes changes to the `api/index.go` file to simplify the server startup and improve code maintainability. The most important changes include removing unused imports and simplifying the `Handler` function.

Codebase simplification:

* [`api/index.go`](diffhunk://#diff-18ca9ac0c83e1edbd6e4f8881b0991a18cab9a62897b4214c3017f0085170763L4-L8): Removed unused imports `fmt` and `time` to clean up the code.
* [`api/index.go`](diffhunk://#diff-18ca9ac0c83e1edbd6e4f8881b0991a18cab9a62897b4214c3017f0085170763L33-R31): Simplified the `Handler` function by removing the asynchronous server startup and graceful shutdown logic, replacing it with a direct call to `app.ServeHTTP(w, r)`.