### PR TITLE
feat(payment): add payment callback route to public routes

### DIFF
--- a/internal/delivery/http/handler/payment/payment_handler_impl.go
+++ b/internal/delivery/http/handler/payment/payment_handler_impl.go
@@ -33,6 +33,7 @@ func NewPaymentHandler(log *logrus.Logger, paymentService payment.PaymentService
 // @Success 201 {object} model.Response[model.PaymentResponse]
 // @Failure 400 {object} model.Error
 // @Failure 500 {object} model.Error
+// @security ApiKeyAuth
 // @Router /payments [post]
 func (h *PaymentHandlerImpl) CreatePayment(ctx echo.Context) error {
 	request := new(model.PaymentRequest)

--- a/internal/delivery/http/route/route.go
+++ b/internal/delivery/http/route/route.go
@@ -43,6 +43,11 @@ func (c Config) PublicRoute() []route.Route {
 			Path:    "/users/refresh",
 			Handler: c.UserHandler.RefreshToken,
 		},
+		{
+			Method:  echo.POST,
+			Path:    "/payments/callback",
+			Handler: c.PaymentHandler.HandleCallback,
+		},
 	}
 }
 
@@ -132,11 +137,6 @@ func (c Config) PrivateRoute() []route.Route {
 			Method:  echo.POST,
 			Path:    "/payments",
 			Handler: c.PaymentHandler.CreatePayment,
-		},
-		{
-			Method:  echo.POST,
-			Path:    "/payments/callback",
-			Handler: c.PaymentHandler.HandleCallback,
 		},
 	}
 }


### PR DESCRIPTION
This pull request includes changes to the payment handling and routing in the HTTP delivery layer of the application. The most significant changes involve adding security to the `CreatePayment` endpoint and modifying the routing configuration for payment callbacks.

### Security Enhancements:
* Added `ApiKeyAuth` security requirement to the `CreatePayment` endpoint in `internal/delivery/http/handler/payment/payment_handler_impl.go`.

### Routing Configuration:
* Added a new public route for handling payment callbacks in `internal/delivery/http/route/route.go`.
* Removed the payment callback route from the private routes in `internal/delivery/http/route/route.go`.