### PR TITLE
fix(event): parse date and time string to time.Time object

### DIFF
--- a/internal/domain/model/event_model.go
+++ b/internal/domain/model/event_model.go
@@ -13,20 +13,20 @@ type EventResponse struct {
 }
 
 type CreateEventRequest struct {
-	Name        string    `json:"name" validate:"required,lte=100"`
-	Description string    `json:"description" validate:"required,lte=255"`
-	Date        time.Time `json:"date" validate:"required"`
-	Time        time.Time `json:"time" validate:"required"`
-	VenueID     uint      `json:"venue_id" validate:"required"`
+	Name        string `json:"name" validate:"required,lte=100"`
+	Description string `json:"description" validate:"required,lte=255"`
+	Date        string `json:"date" validate:"required" example:"2024-03-20"`
+	Time        string `json:"time" validate:"required" example:"14:30:00"`
+	VenueID     uint   `json:"venue_id" validate:"required"`
 }
 
 type UpdateEventRequest struct {
-	ID          uint      `param:"id" validate:"required"`
-	Name        string    `json:"name" validate:"omitempty,lte=100"`
-	Description string    `json:"description" validate:"omitempty,lte=255"`
-	Date        time.Time `json:"date" validate:"omitempty"`
-	Time        time.Time `json:"time" validate:"omitempty"`
-	VenueID     uint      `json:"venue_id" validate:"omitempty"`
+	ID          uint   `param:"id" validate:"required"`
+	Name        string `json:"name" validate:"omitempty,lte=100"`
+	Description string `json:"description" validate:"omitempty,lte=255"`
+	Date        string `json:"date" validate:"omitempty" example:"2024-03-20"`
+	Time        string `json:"time" validate:"omitempty" example:"14:30:00"`
+	VenueID     uint   `json:"venue_id" validate:"omitempty"`
 }
 
 type GetEventRequest struct {
@@ -43,8 +43,8 @@ type EventsRequest struct {
 type EventSearchRequest struct {
 	Name        string `query:"name" validate:"omitempty,lte=100"`
 	Description string `query:"description" validate:"omitempty,lte=255"`
-	Date        string `query:"date" validate:"omitempty"`
-	Time        string `query:"time" validate:"omitempty"`
+	Date        string `query:"date" validate:"omitempty,datetime=2006-01-02"`
+	Time        string `query:"time" validate:"omitempty,datetime=15:04:05"`
 	VenueID     uint   `query:"venue_id" validate:"omitempty"`
 	Page        int    `query:"page" validate:"numeric"`
 	Size        int    `query:"size" validate:"numeric"`


### PR DESCRIPTION
This pull request includes several changes to the `internal/domain/model/event_model.go` and `internal/service/event/event_service_impl.go` files to improve date and time handling by converting them from `time.Time` to `string` and adding parsing logic.

Improvements to date and time handling:

* [`internal/domain/model/event_model.go`](diffhunk://#diff-41fd2b3bf7bb92307b26b28c5d57a385c8bd97f50528165aae5e8f7bd693f6fbL18-R28): Changed `Date` and `Time` fields in `CreateEventRequest`, `UpdateEventRequest`, and `EventSearchRequest` structs from `time.Time` to `string` and added example values for validation. [[1]](diffhunk://#diff-41fd2b3bf7bb92307b26b28c5d57a385c8bd97f50528165aae5e8f7bd693f6fbL18-R28) [[2]](diffhunk://#diff-41fd2b3bf7bb92307b26b28c5d57a385c8bd97f50528165aae5e8f7bd693f6fbL46-R47)

* [`internal/service/event/event_service_impl.go`](diffhunk://#diff-735ad13f99ced032c8fedab4f8fa5b56591a44901e828a040a3fe157569bd8e5R41-R45): Added constants `dateLayout` and `timeLayout` for date and time formats.

* [`internal/service/event/event_service_impl.go`](diffhunk://#diff-735ad13f99ced032c8fedab4f8fa5b56591a44901e828a040a3fe157569bd8e5R255-R275): Added `parseDateTime` function to parse and combine date and time strings into a `time.Time` object.

* [`internal/service/event/event_service_impl.go`](diffhunk://#diff-735ad13f99ced032c8fedab4f8fa5b56591a44901e828a040a3fe157569bd8e5R54-R64): Updated `CreateEvent` and `UpdateEvent` methods to use the `parseDateTime` function for parsing date and time strings. [[1]](diffhunk://#diff-735ad13f99ced032c8fedab4f8fa5b56591a44901e828a040a3fe157569bd8e5R54-R64) [[2]](diffhunk://#diff-735ad13f99ced032c8fedab4f8fa5b56591a44901e828a040a3fe157569bd8e5R88-R99)