### PR TITLE
fix(event): remove status field and fix time format

### DIFF
--- a/internal/domain/model/event_model.go
+++ b/internal/domain/model/event_model.go
@@ -13,7 +13,6 @@ type EventResponse struct {
 	Date        time.Time      `json:"date"`
 	Time        helper.SQLTime `json:"time"`
 	VenueID     uint           `json:"venue_id"`
-	Status      string         `json:"status"`
 }
 
 type CreateEventRequest struct {

--- a/pkg/helper/sql_helper.go
+++ b/pkg/helper/sql_helper.go
@@ -2,12 +2,34 @@ package helper
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"time"
 )
 
 // SQLTime is a custom type to handle PostgreSQL's time type
 type SQLTime time.Time
+
+// MarshalJSON implements the json.Marshaler interface
+func (st SQLTime) MarshalJSON() ([]byte, error) {
+	t := time.Time(st)
+	return json.Marshal(t.Format("15:04:05"))
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (st *SQLTime) UnmarshalJSON(data []byte) error {
+	var timeStr string
+	if err := json.Unmarshal(data, &timeStr); err != nil {
+		return err
+	}
+
+	t, err := time.Parse("15:04:05", timeStr)
+	if err != nil {
+		return err
+	}
+	*st = SQLTime(t)
+	return nil
+}
 
 // Scan implements the sql.Scanner interface
 func (st *SQLTime) Scan(value interface{}) error {
@@ -33,4 +55,9 @@ func (st *SQLTime) Scan(value interface{}) error {
 // Value implements the driver.Valuer interface
 func (st SQLTime) Value() (driver.Value, error) {
 	return time.Time(st).Format("15:04:05"), nil
+}
+
+// String returns the time in HH:MM:SS format
+func (st SQLTime) String() string {
+	return time.Time(st).Format("15:04:05")
 }


### PR DESCRIPTION
This pull request includes several changes to the `internal/domain/model/event_model.go` and `pkg/helper/sql_helper.go` files. The most important changes involve the removal of the `Status` field from the `EventResponse` struct and the addition of JSON marshaling and unmarshaling methods for the `SQLTime` type.

Changes to `EventResponse` struct:

* [`internal/domain/model/event_model.go`](diffhunk://#diff-41fd2b3bf7bb92307b26b28c5d57a385c8bd97f50528165aae5e8f7bd693f6fbL16): Removed the `Status` field from the `EventResponse` struct.

Enhancements to `SQLTime` type:

* [`pkg/helper/sql_helper.go`](diffhunk://#diff-6a6449fefeb242790b41f0f4075d0e0fbcdbd09cfee57ed1ce6c08fa4675a93fR5-R33): Added `MarshalJSON` and `UnmarshalJSON` methods to the `SQLTime` type to handle JSON serialization and deserialization.
* [`pkg/helper/sql_helper.go`](diffhunk://#diff-6a6449fefeb242790b41f0f4075d0e0fbcdbd09cfee57ed1ce6c08fa4675a93fR59-R63): Added a `String` method to the `SQLTime` type to return the time in `HH:MM:SS` format.