### PR TITLE
chore(go): update go version to 1.23.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.23.3'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
This pull request includes an update to the Go version used in the GitHub Actions workflow.

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL22-R22): Updated the Go version from `1.20` to `1.23.3` in the `jobs:` section.